### PR TITLE
Feature- Filter out missing elements

### DIFF
--- a/examples/App.tsx
+++ b/examples/App.tsx
@@ -11,7 +11,7 @@ const Card = styled.div({
   padding: '1rem',
 });
 
-const messages = ['hello1', 'world2', 'hello3'];
+const messages = ['hello1', 'world2', 'hidden', 'hello3'];
 
 const node = document.getElementById('tourguide-root');
 
@@ -37,8 +37,9 @@ function App() {
       >
         <div>
           <h2 {...getAnchorElProps(1)}>Some cool subtitle 2</h2>
+          {false && <h2 {...getAnchorElProps(2)}>Some hidden feature</h2>}
           <Card {...getAnchorElProps(0)}>Some random card with content</Card>
-          <p {...getAnchorElProps(2)}>Some cool content 3</p>
+          <p {...getAnchorElProps(3)}>Some cool content 3</p>
         </div>
         <button onClick={toggle}>show</button>
       </div>

--- a/src/Tourguide.tsx
+++ b/src/Tourguide.tsx
@@ -110,6 +110,22 @@ const Tourguide = (props: TourguideProps) => {
     }
   };
 
+  const filterOutUnused = useCallback(
+    (value?: any) => {
+      return Array.isArray(value)
+        ? value
+            .map((item, index: number) => {
+              if (!!allAnchorEls[index]) {
+                return item;
+              }
+              return undefined;
+            })
+            .filter((item) => !!item)
+        : value;
+    },
+    [allAnchorEls]
+  );
+
   useEffect(() => {
     if (show) {
       document.addEventListener('keydown', handleKeyDown);
@@ -126,32 +142,15 @@ const Tourguide = (props: TourguideProps) => {
     }
   }, [anchorEls.length, precondition, setStatus]);
 
-  const filterOutUnusedTooltips = () => {
-    const filteredComponent = Array.isArray(TooltipComponent)
-      ? TooltipComponent.map((item, index: number) => {
-          if (!!allAnchorEls[index]) {
-            return item;
-          }
-        }).filter((item) => !!item)
-      : TooltipComponent;
+  useEffect(() => {
+    setComponent(
+      filterOutUnused(TooltipComponent) as TourguideProps['tooltip']
+    );
+  }, [TooltipComponent, filterOutUnused]);
 
-    setComponent(filteredComponent as TourguideProps['tooltip']);
-  };
-
-  const filterOutUnusedContent = () => {
-    const filteredContent = allContent
-      ?.map((item, index: number) => {
-        if (!!allAnchorEls[index]) {
-          return item;
-        }
-      })
-      .filter((item) => !!item);
-
-    setContent(filteredContent);
-  };
-
-  useEffect(filterOutUnusedTooltips, [TooltipComponent]);
-  useEffect(filterOutUnusedContent, [allContent]);
+  useEffect(() => {
+    setContent(filterOutUnused(allContent));
+  }, [allContent, filterOutUnused]);
 
   const opacityAnim = useSpring({
     opacity: show ? 1 : 0,

--- a/src/useTourguide.ts
+++ b/src/useTourguide.ts
@@ -16,25 +16,28 @@ export default function useTourguide() {
   const [curPos, setCurPos] = useState(0);
   const [status, setStatus] = useState<TourGuideStatus>('idle');
 
-  const handleRef = (position: number) => (node: HTMLElement | null) => {
-    if (
-      node !== null &&
-      typeof position === 'number' &&
-      !node.isEqualNode(allAnchorEls[position]?.node)
-    ) {
-      setAllAnchorEls((prevEls) => {
-        const anchors = [...prevEls];
-        anchors[position] = {
-          node,
-          position,
-        };
-        return anchors;
-      });
-      if (status === 'idle') {
-        setStatus('initializing');
+  const handleRef = useCallback(
+    (position: number) => (node: HTMLElement | null) => {
+      if (
+        node !== null &&
+        typeof position === 'number' &&
+        !node.isEqualNode(allAnchorEls[position]?.node)
+      ) {
+        setAllAnchorEls((prevEls) => {
+          const anchors = [...prevEls];
+          anchors[position] = {
+            node,
+            position,
+          };
+          return anchors;
+        });
+        if (status === 'idle') {
+          setStatus('initializing');
+        }
       }
-    }
-  };
+    },
+    [status, allAnchorEls]
+  );
 
   const getAnchorElProps = useCallback(
     (position: number) => ({
@@ -117,7 +120,7 @@ export default function useTourguide() {
       toggle,
       close,
       status,
-      allAnchorEls.length,
+      allAnchorEls,
     ]
   );
 }


### PR DESCRIPTION
Want to be able to disable components from the tour without having to change the config.
If a DOM node is missing from the order of tour positions we will remove the corresponding messages and tool tips.